### PR TITLE
chore: Improve inference speed by caching sin/cos in RotaryEmbedding

### DIFF
--- a/dia2/core/layers.py
+++ b/dia2/core/layers.py
@@ -94,9 +94,7 @@ class Attention(nn.Module):
         eps = config.model.normalization_layer_epsilon
         self.q_norm = nn.RMSNorm(self.head_dim, eps=eps, dtype=torch.float32, device=device)
         self.k_norm = nn.RMSNorm(self.head_dim, eps=eps, dtype=torch.float32, device=device)
-        
-        # Pre-calculate RoPE for the full context + small buffer
-        rope_len = config.runtime.max_context_steps + 256
+        rope_len = config.runtime.max_context_steps
         self.rotary = RotaryEmbedding(
             self.head_dim,
             config.model.rope_min_timescale,


### PR DESCRIPTION
Hi,

Thanks for the nice upgrade of Dia! 

I was playing around and tried to squeeze some more tokens/s. I managed to improve performance slightly by caching the sin/cos calculation for the RoPE length. Since the context length is not that long (1500) there is almost no increase in memory usage. 

Here is a simple profiling script that I used:

```python
import time
import torch
from dia2.core.layers import RotaryEmbedding
from torch.profiler import ProfilerActivity, profile

rot = RotaryEmbedding(128, 1., 10000., device="cuda")

# Warmup
for i in range(10):
    q_proj = torch.rand((2, 1, 16, 128), device="cuda")
    pos = torch.ones((2,1), device="cuda", dtype=torch.int)
    _ = rot.forward(q_proj, pos)
torch.cuda.synchronize()

# Timing measurements
with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
    torch.cuda.synchronize()
    start_time = time.perf_counter()
    
    for i in range(100):
        q_proj = torch.rand((2, 1, 16, 128), device="cuda")
        pos = torch.ones((2,1), device="cuda", dtype=torch.int)
        forward = rot.forward(q_proj, pos)
    
    torch.cuda.synchronize()
    end_time = time.perf_counter()

total_time = end_time - start_time
avg_time = total_time / 100

print(f"Total time: {total_time:.4f} seconds")
print(f"Average time per iteration: {avg_time:.6f} seconds")
print(f"Throughput: {100/total_time:.2f} iterations/second")

prof.export_chrome_trace("trace_updated.json")

# Difference ~5550 iterations/second instead of 5000 iterations/second for the current implementation
```