### PR TITLE
Update setuptools configuration to use package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,6 @@ name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
-[tool.setuptools]
-packages = ["dia2", "dia2.audio", "dia2.core", "dia2.runtime"]
+[tool.setuptools.packages.find]
+include = ["dia2", "dia2.*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,5 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [tool.setuptools]
-packages = ["dia2"]
+packages = ["dia2", "dia2.audio", "dia2.core", "dia2.runtime"]
+


### PR DESCRIPTION
## Summary
Updated the setuptools configuration in `pyproject.toml` to use automatic package discovery instead of manual package specification.

## Key Changes
- Changed from static `[tool.setuptools]` configuration to `[tool.setuptools.packages.find]` for dynamic package discovery
- Updated package specification from `packages = ["dia2"]` to `include = ["dia2", "dia2.*"]` to automatically discover the main package and all subpackages

## Implementation Details
This change enables setuptools to automatically discover and include the `dia2` package and all its subpackages (indicated by the `dia2.*` pattern), making the configuration more maintainable and reducing the need for manual updates when new subpackages are added to the project.

https://claude.ai/code/session_01GbqWPZjVDJUi7MGXy15dnh